### PR TITLE
Add manual OAuth token refresh workflow

### DIFF
--- a/.github/workflows/refresh-oauth-token.yml
+++ b/.github/workflows/refresh-oauth-token.yml
@@ -1,0 +1,42 @@
+name: Refresh OAuth Token
+
+on:
+  workflow_dispatch:
+    inputs:
+      update_secrets:
+        description: 'Update GitHub secrets with new tokens'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  refresh-token:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      secrets: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Refresh OAuth Token
+        env:
+          CLAUDE_REFRESH_TOKEN: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
+          UPDATE_GITHUB_SECRET: ${{ inputs.update_secrets }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          node scripts/refresh-token.js
+      
+      - name: Verify token refresh
+        if: success()
+        run: |
+          echo "✅ OAuth token refreshed successfully"
+          echo "Token refresh completed at: $(date)"

--- a/.github/workflows/test-refresh-oauth.yml
+++ b/.github/workflows/test-refresh-oauth.yml
@@ -1,0 +1,31 @@
+name: Test OAuth Refresh
+
+on:
+  push:
+    branches:
+      - add-oauth-refresh-workflow
+
+jobs:
+  test-refresh:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Test refresh script exists and has correct syntax
+        run: |
+          echo "Testing refresh script..."
+          node -c scripts/refresh-token.js
+          echo "✅ Script syntax is valid"
+      
+      - name: Test workflow file
+        run: |
+          echo "Checking workflow file exists..."
+          ls -la .github/workflows/refresh-oauth-token.yml
+          echo "✅ Workflow file exists"


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow for manual OAuth token refresh
- Workflow can be triggered manually via workflow_dispatch
- Uses existing refresh-token.js script with optional GitHub secrets update

## Test plan
- [x] Verify workflow file syntax is valid
- [ ] Test workflow dispatch from Actions tab
- [ ] Confirm token refresh works with valid CLAUDE_REFRESH_TOKEN secret
- [ ] Verify GitHub secrets update when enabled

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)